### PR TITLE
Add a method to get all schemas from Aries Cloudagent

### DIFF
--- a/src/main/java/org/hyperledger/aries/AriesClient.java
+++ b/src/main/java/org/hyperledger/aries/AriesClient.java
@@ -64,6 +64,7 @@ import org.hyperledger.aries.api.revocation.RevokeRequest;
 import org.hyperledger.aries.api.revocation.*;
 import org.hyperledger.aries.api.schema.SchemaSendRequest;
 import org.hyperledger.aries.api.schema.SchemaSendResponse.Schema;
+import org.hyperledger.aries.api.schema.SchemasCreatedFilter;
 import org.hyperledger.aries.api.server.AdminConfig;
 import org.hyperledger.aries.api.server.AdminStatusLiveliness;
 import org.hyperledger.aries.api.server.AdminStatusReadiness;
@@ -1564,6 +1565,23 @@ public class AriesClient extends BaseClient {
     public Optional<Schema> schemasGetById(@NonNull String schemaId) throws IOException {
         Request req = buildGet(url + "/schemas/" + schemaId);
         return getWrapped(raw(req), "schema", Schema.class);
+    }
+    
+    /**
+     * Loads all schemas from the ledger, which where created by the DID of this cloudagent.
+     * 
+     * @param filter allows to look only for some schemas
+     * @return List of Schema names
+     * @throws IOException if the request could not be executed due to cancellation, a connectivity problem or timeout.
+     */
+    public Optional<List<String>> schemasCreated(@Nullable SchemasCreatedFilter filter) throws IOException {
+        HttpUrl.Builder b = Objects.requireNonNull(HttpUrl
+                .parse(url + "/schemas/created")).newBuilder();
+        if (filter != null) {
+            filter.buildParams(b);
+        }
+        Request req = buildGet(b.toString());
+        return getWrapped(raw(req), "schema_ids", List.class);
     }
 
     // ----------------------------------------------------

--- a/src/main/java/org/hyperledger/aries/api/schema/SchemasCreatedFilter.java
+++ b/src/main/java/org/hyperledger/aries/api/schema/SchemasCreatedFilter.java
@@ -1,0 +1,18 @@
+package org.hyperledger.aries.api.schema;
+
+import org.hyperledger.aries.api.AcaPyRequestFilter;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * A filter which can be used to let aca-py look for special criteria of schemas.
+ */
+@Data
+@Builder
+public class SchemasCreatedFilter implements AcaPyRequestFilter {
+    private String schemaId;
+    private String schemaIssuerDid;
+    private String schemaName;
+    private String schemaVersion;
+}

--- a/src/test/java/org/hyperledger/aries/api/schema/MockedSchemaTest.java
+++ b/src/test/java/org/hyperledger/aries/api/schema/MockedSchemaTest.java
@@ -15,6 +15,9 @@ import org.hyperledger.aries.api.schema.SchemaSendResponse.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -53,6 +56,26 @@ class MockedSchemaTest extends MockedTestBase {
         Assertions.assertTrue(res.get().getId().startsWith("M6Mbe3qx7vB4wpZF4sBRjt"));
         Assertions.assertEquals("bank_account", res.get().getName());
         Assertions.assertEquals(571, res.get().getSeqNo());
+        log.debug(pretty.toJson(res.get()));
+    }
+    
+    @Test
+    void testGetAllSchemas() throws Exception {
+    	JsonArray jsonArray = new JsonArray();
+    	jsonArray.add("exampleSchemaId");
+    	JsonObject jsonObject = new JsonObject();
+    	jsonObject.add("schema_ids", jsonArray);
+    	
+        String json = jsonObject.toString();
+        System.out.println(json);
+
+        server.enqueue(new MockResponse().setBody(json));
+
+        Optional<List<String>> res = ac.schemasCreated(SchemasCreatedFilter.builder().build());
+
+        Assertions.assertTrue(res.isPresent());
+        Assertions.assertEquals(1, res.get().size());
+        
         log.debug(pretty.toJson(res.get()));
     }
 


### PR DESCRIPTION
This is the second approach to propose a method to get all Schema Ids from the Aries Cloudagent. Corrections include a filter as suggested and a simple unit test.

Signed-off-by: Stefan Hauffe <stefan.hauffe@mgm-tp.com>