### PR TITLE
Extend present proof request builder with lombok.singular

### DIFF
--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -53,10 +53,10 @@ public class PresentProofRequest {
         private ProofNonRevoked nonRevoked;
 
         @Singular
-        private Map<String, ProofRequestedAttributes> requestedAttributes = new LinkedHashMap<>();
+        private Map<String, ProofRequestedAttributes> requestedAttributes;
 
         @Singular
-        private Map<String, ProofRequestedPredicates> requestedPredicates = new LinkedHashMap<>();
+        private Map<String, ProofRequestedPredicates> requestedPredicates;
 
         @Data @NoArgsConstructor @AllArgsConstructor @Builder
         public static class ProofRequestedAttributes {

--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -52,10 +52,10 @@ public class PresentProofRequest {
 
         private ProofNonRevoked nonRevoked;
 
-        @Builder.Default
+        @Singular
         private Map<String, ProofRequestedAttributes> requestedAttributes = new LinkedHashMap<>();
 
-        @Builder.Default
+        @Singular
         private Map<String, ProofRequestedPredicates> requestedPredicates = new LinkedHashMap<>();
 
         @Data @NoArgsConstructor @AllArgsConstructor @Builder
@@ -64,6 +64,7 @@ public class PresentProofRequest {
             /** @since 0.5.4 */
             private List<String> names;
             private ProofNonRevoked nonRevoked;
+            @Singular
             @JsonSerialize(using = JsonObjectArraySerializer.class)
             @JsonDeserialize(using = JsonObjectArrayDeserializer.class)
             private List<JsonObject> restrictions = new ArrayList<>();
@@ -75,6 +76,7 @@ public class PresentProofRequest {
             private ProofNonRevoked nonRevoked;
             private IndyProofReqPredSpec.PTypeEnum pType;
             private String pValue;
+            @Singular
             @JsonSerialize(using = JsonObjectArraySerializer.class)
             @JsonDeserialize(using = JsonObjectArrayDeserializer.class)
             private List<JsonObject> restrictions = new ArrayList<>();

--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -18,17 +18,17 @@ import org.hyperledger.aries.api.serializer.JsonObjectArraySerializer;
 import org.hyperledger.aries.config.CredDefId;
 import org.hyperledger.aries.config.GsonConfig;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Aka PresentationSendRequestRequest
  * This model is used to send a presentation request, or in other words to request a proof.
- *
  */
-@Data @NoArgsConstructor @AllArgsConstructor @Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class PresentProofRequest {
 
     private String connectionId;
@@ -67,7 +67,7 @@ public class PresentProofRequest {
             @Singular
             @JsonSerialize(using = JsonObjectArraySerializer.class)
             @JsonDeserialize(using = JsonObjectArrayDeserializer.class)
-            private List<JsonObject> restrictions = new ArrayList<>();
+            private List<JsonObject> restrictions;
         }
 
         @Data @NoArgsConstructor @AllArgsConstructor @Builder
@@ -79,7 +79,7 @@ public class PresentProofRequest {
             @Singular
             @JsonSerialize(using = JsonObjectArraySerializer.class)
             @JsonDeserialize(using = JsonObjectArrayDeserializer.class)
-            private List<JsonObject> restrictions = new ArrayList<>();
+            private List<JsonObject> restrictions;
         }
 
         @Data @NoArgsConstructor @AllArgsConstructor @Builder

--- a/src/test/resources/spotbugs-exclude.xml
+++ b/src/test/resources/spotbugs-exclude.xml
@@ -9,6 +9,19 @@
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE,RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
     </Match>
 
+
+    <!-- Ignore warnings for Lombok builder classes working with @Singular on maps and lists -->
+    <Match>
+        <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+        <And>
+            <Or>
+                <Method  name="~clear.+" />
+                <Method  name="build" />
+            </Or>
+            <Class name="~.+Builder.*"/>
+        </And>
+    </Match>
+
     <!-- Exclude generated code -->
     <Match>
         <Package name="org.hyperledger.acy_py.generated.model" />


### PR DESCRIPTION
@lombok.Singular is needed to map ProofTemplates to PresentProofRequest efficiently.

The major change is, that the fields PresentProofRequest#requestedPredicates and PresentProofRequest#requestedAttributes now have a java.util.HashMap instead of a java.util.LinkedHashMap when PresentProofRequestBuilder is used.