### PR TITLE
extend presentproofrequest-restrictions-for-generic-restrictions

### DIFF
--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -10,6 +10,7 @@ package org.hyperledger.aries.api.present_proof;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
 import lombok.*;
 import org.hyperledger.acy_py.generated.model.IndyProofReqPredSpec;
@@ -17,6 +18,7 @@ import org.hyperledger.aries.api.serializer.JsonObjectArrayDeserializer;
 import org.hyperledger.aries.api.serializer.JsonObjectArraySerializer;
 import org.hyperledger.aries.config.CredDefId;
 import org.hyperledger.aries.config.GsonConfig;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -33,13 +35,17 @@ public class PresentProofRequest {
 
     private String connectionId;
 
-    @NonNull private ProofRequest proofRequest;
+    @NonNull
+    private ProofRequest proofRequest;
 
     private Boolean trace;
 
     private String comment;
 
-    @Data @NoArgsConstructor @AllArgsConstructor @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class ProofRequest {
 
         @Builder.Default
@@ -58,10 +64,15 @@ public class PresentProofRequest {
         @Singular
         private Map<String, ProofRequestedPredicates> requestedPredicates;
 
-        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
         public static class ProofRequestedAttributes {
             private String name;
-            /** @since 0.5.4 */
+            /**
+             * @since 0.5.4
+             */
             private List<String> names;
             private ProofNonRevoked nonRevoked;
             @Singular
@@ -70,7 +81,10 @@ public class PresentProofRequest {
             private List<JsonObject> restrictions;
         }
 
-        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
         public static class ProofRequestedPredicates {
             private String name;
             private ProofNonRevoked nonRevoked;
@@ -82,14 +96,21 @@ public class PresentProofRequest {
             private List<JsonObject> restrictions;
         }
 
-        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
         public static class ProofNonRevoked {
             private Long from;
             private Long to;
         }
 
-        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        @Data
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
         public static class ProofRestrictions {
+            private static final String GENERIC_RESTRICTIONS="GenericRestrictions";
             private String schemaId;
 
             private String schemaName;
@@ -103,8 +124,21 @@ public class PresentProofRequest {
 
             private String issuerDid;
 
+            @SerializedName(value = GENERIC_RESTRICTIONS)
+            @Singular
+            private Map<String, String> genericRestrictions;
+
             public JsonObject toJsonObject() {
-                return GsonConfig.defaultConfig().toJsonTree(this).getAsJsonObject();
+                JsonObject result = GsonConfig.defaultConfig().toJsonTree(this)
+                        .getAsJsonObject();
+                return flattenGenericRestrictions(result);
+            }
+
+            @NotNull
+            private JsonObject flattenGenericRestrictions(JsonObject result) {
+                result.remove(GENERIC_RESTRICTIONS);
+                genericRestrictions.forEach((k,v)-> result.add(k,new JsonPrimitive(v)));
+                return result;
             }
 
             public static JsonObject addNameValue(
@@ -113,6 +147,14 @@ public class PresentProofRequest {
                     @NonNull JsonObject restriction) {
                 restriction.addProperty("attr::" + name + "::value", value);
                 return restriction;
+            }
+
+            // This extends the lombok generated builder with contained methods.
+            public static class ProofRestrictionsBuilder{
+                public ProofRestrictionsBuilder addAttributeValueRestriction(@NonNull String name, @NonNull String value) {
+                    this.genericRestriction("attr::" + name + "::value", value);
+                    return this;
+                }
             }
         }
     }

--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -18,7 +18,6 @@ import org.hyperledger.aries.api.serializer.JsonObjectArrayDeserializer;
 import org.hyperledger.aries.api.serializer.JsonObjectArraySerializer;
 import org.hyperledger.aries.config.CredDefId;
 import org.hyperledger.aries.config.GsonConfig;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -134,7 +133,7 @@ public class PresentProofRequest {
                 return flattenGenericRestrictions(result);
             }
 
-            @NotNull
+            @NonNull
             private JsonObject flattenGenericRestrictions(JsonObject result) {
                 result.remove(GENERIC_RESTRICTIONS);
                 genericRestrictions.forEach((k,v)-> result.add(k,new JsonPrimitive(v)));

--- a/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
+++ b/src/main/java/org/hyperledger/aries/api/present_proof/PresentProofRequest.java
@@ -109,7 +109,6 @@ public class PresentProofRequest {
         @AllArgsConstructor
         @Builder
         public static class ProofRestrictions {
-            private static final String GENERIC_RESTRICTIONS="GenericRestrictions";
             private String schemaId;
 
             private String schemaName;
@@ -123,9 +122,8 @@ public class PresentProofRequest {
 
             private String issuerDid;
 
-            @SerializedName(value = GENERIC_RESTRICTIONS)
             @Singular
-            private Map<String, String> genericRestrictions;
+            private transient Map<String, String> genericRestrictions;
 
             public JsonObject toJsonObject() {
                 JsonObject result = GsonConfig.defaultConfig().toJsonTree(this)
@@ -135,7 +133,6 @@ public class PresentProofRequest {
 
             @NonNull
             private JsonObject flattenGenericRestrictions(JsonObject result) {
-                result.remove(GENERIC_RESTRICTIONS);
                 genericRestrictions.forEach((k,v)-> result.add(k,new JsonPrimitive(v)));
                 return result;
             }

--- a/src/test/java/org/hyperledger/aries/api/present_proof/PresentProofRequestTest.java
+++ b/src/test/java/org/hyperledger/aries/api/present_proof/PresentProofRequestTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/acapy-java-client
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.aries.api.present_proof;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PresentProofRequestTest {
+
+    @Test
+    public void testRestrictionWithSchemaIdAndIssuer(){
+        String sut = PresentProofRequest.ProofRequest.ProofRestrictions.builder()
+                .issuerDid("issuerId")
+                .schemaId("schemaId")
+                .build()
+                .toJsonObject()
+                .toString();
+        Assertions.assertEquals("{\"schema_id\":\"schemaId\",\"issuer_did\":\"issuerId\"}", sut);
+    }
+
+    @Test
+    public void testAttributeValueWithPostProcessing(){
+        JsonObject obj = PresentProofRequest.ProofRequest.ProofRestrictions.builder()
+                .issuerDid("issuerId")
+                .schemaId("schemaId")
+                .build()
+                .toJsonObject();
+        String sut = PresentProofRequest.ProofRequest.ProofRestrictions.addNameValue("attrName", "value", obj).toString();
+        Assertions.assertEquals("{\"schema_id\":\"schemaId\"," +
+                "\"issuer_did\":\"issuerId\"," +
+                "\"attr::attrName::value\":\"value\"}", sut);
+    }
+
+    @Test
+    public void testAttributeValueWithBuilderFunction(){
+        String sut = PresentProofRequest.ProofRequest.ProofRestrictions.builder()
+                .issuerDid("issuerId")
+                .schemaId("schemaId")
+                .addAttributeValueRestriction("attrName", "value")
+                .build()
+                .toJsonObject()
+                .toString();
+        Assertions.assertEquals("{\"schema_id\":\"schemaId\"," +
+                "\"issuer_did\":\"issuerId\"," +
+                "\"attr::attrName::value\":\"value\"}", sut);
+    }
+}


### PR DESCRIPTION
Added support for generic restrictions in PresentProofRequest. Added addAttributeValueRestriction for convenience to the ProofRestrictionsBuilder.

Signed-off-by: Lars Wegner <lars.wegner2@de.bosch.com>