### PR TITLE
Integration test with multiple aca-py agents

### DIFF
--- a/src/test/java/org/hyperledger/aries/MultiIntegrationTestBase.java
+++ b/src/test/java/org/hyperledger/aries/MultiIntegrationTestBase.java
@@ -20,7 +20,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public abstract class MultiIntegrationTestBase {
 
-    private final Logger log = LoggerFactory.getLogger(IntegrationTestBase.class);
+    private final Logger log = LoggerFactory.getLogger(MultiIntegrationTestBase.class);
 
     public static final String ARIES_VERSION = "bcgovimages/aries-cloudagent:py36-1.16-1_0.7.2";
     public static final Integer ARIES_ENDPOINT_PORT = 8030;

--- a/src/test/java/org/hyperledger/aries/MultiIntegrationTestBase.java
+++ b/src/test/java/org/hyperledger/aries/MultiIntegrationTestBase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/acapy-java-client
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.aries;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class MultiIntegrationTestBase {
+
+    private final Logger log = LoggerFactory.getLogger(IntegrationTestBase.class);
+
+    public static final String ARIES_VERSION = "bcgovimages/aries-cloudagent:py36-1.16-1_0.7.2";
+    public static final Integer ARIES_ENDPOINT_PORT = 8030;
+    public static final Integer ARIES_ADMIN_PORT = 8031;
+    public static final Integer ARIES_ENDPOINT_PORT_2 = 8040;
+    public static final Integer ARIES_ADMIN_PORT_2 = 8041;
+
+    protected AriesClient ac;
+    protected AriesClient ac2;
+
+    Network network = Network.newNetwork();
+
+    @Container
+    protected GenericContainer<?> ariesContainer = new GenericContainer<>(ARIES_VERSION)
+            .withNetwork(network)
+            .withNetworkAliases("agent_1")
+            .withExposedPorts(ARIES_ADMIN_PORT)
+            .withCommand("start"
+                    + " -it http 0.0.0.0 " + ARIES_ENDPOINT_PORT
+                    + " -ot http"
+                    + " --admin 0.0.0.0 " + ARIES_ADMIN_PORT
+                    + " --admin-insecure-mode"
+                    + " --log-level debug"
+                    + " -e http://agent_1:" + ARIES_ENDPOINT_PORT
+                    + " --genesis-url https://indy-test.bosch-digital.de/genesis"
+                    + " --auto-ping-connection"
+                    + " --wallet-type indy"
+                    + " --wallet-name agent1"
+                    + " --wallet-key agent1key"
+                    + " --auto-provision"
+                    + " --plugin aries_cloudagent.messaging.jsonld")
+            .waitingFor(Wait.defaultWaitStrategy())
+            .withLogConsumer(new Slf4jLogConsumer(log))
+            ;
+
+    @Container
+    protected GenericContainer<?> ariesContainer2 = new GenericContainer<>(ARIES_VERSION)
+            .withExposedPorts(ARIES_ADMIN_PORT_2)
+            .withNetwork(network)
+            .withNetworkAliases("agent_2")
+            .withCommand("start"
+                    + " -it http 0.0.0.0 " + ARIES_ENDPOINT_PORT_2
+                    + " -ot http"
+                    + " --admin 0.0.0.0 " + ARIES_ADMIN_PORT_2
+                    + " --admin-insecure-mode"
+                    + " --log-level debug"
+                    + " -e http://agent_2:" + ARIES_ENDPOINT_PORT_2
+                    + " --genesis-url https://indy-test.bosch-digital.de/genesis"
+                    + " --auto-ping-connection"
+                    + " --wallet-type indy"
+                    + " --wallet-name agent2"
+                    + " --wallet-key agent2key"
+                    + " --auto-provision"
+                    + " --plugin aries_cloudagent.messaging.jsonld")
+            .waitingFor(Wait.defaultWaitStrategy())
+            .withLogConsumer(new Slf4jLogConsumer(log))
+            ;
+
+    @BeforeEach
+    void setup() {
+        ac = AriesClient.builder()
+                .url("http://" + ariesContainer.getHost() + ":" + ariesContainer.getMappedPort(ARIES_ADMIN_PORT))
+                .build();
+        ac2 = AriesClient.builder()
+                .url("http://" + ariesContainer.getHost() + ":" + ariesContainer2.getMappedPort(ARIES_ADMIN_PORT_2))
+                .build();
+    }
+}

--- a/src/test/java/org/hyperledger/aries/api/connection/MultiConnectionRecordTest.java
+++ b/src/test/java/org/hyperledger/aries/api/connection/MultiConnectionRecordTest.java
@@ -8,7 +8,7 @@
 package org.hyperledger.aries.api.connection;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hyperledger.aries.IntegrationTestBase;
+import org.hyperledger.aries.MultiIntegrationTestBase;
 import org.hyperledger.aries.api.exception.AriesException;
 import org.hyperledger.acy_py.generated.model.ConnectionInvitation;
 import org.junit.jupiter.api.Assertions;
@@ -21,75 +21,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
-public class ConnectionRecordTest extends IntegrationTestBase {
-
-    @Test
-    void testDeleteConnection() {
-        assertThrows(AriesException.class, () -> ac.connectionsRemove("1"));
-    }
-
-    @Test
-    void testGetConnections() throws Exception {
-        final Optional<List<ConnectionRecord>> connections = ac.connections(
-                ConnectionFilter.builder().state(ConnectionState.ACTIVE).build());
-        assertTrue(connections.isPresent());
-        assertEquals(0, connections.get().size());
-    }
-
-    @Test
-    void testGetConnectionsWrongFilter() {
-        assertThrows(AriesException.class, () -> ac.connections(
-            ConnectionFilter.builder().myDid("wrong_format").build()));
-    }
-
-    @Test
-    void testCreateInvitation() throws Exception {
-        final Optional<CreateInvitationResponse> inv = ac.connectionsCreateInvitation(
-                CreateInvitationRequest
-                        .builder()
-                        .recipientKeys(List.of())
-                        .build(),
-                CreateInvitationParams
-                        .builder()
-                        .autoAccept(Boolean.TRUE)
-                        .build());
-        assertTrue(inv.isPresent());
-        assertNotNull(inv.get().getInvitationUrl());
-        log.debug("{}", inv.get());
-    }
-
-    @Test
-    void testMetadata() throws Exception {
-        ac.connectionsCreateInvitation(
-                CreateInvitationRequest
-                        .builder()
-                        .recipientKeys(List.of())
-                        .build(),
-                CreateInvitationParams
-                        .builder()
-                        .autoAccept(Boolean.TRUE)
-                        .build());
-
-        Optional<List<ConnectionRecord>> connections = ac.connections();
-        Assertions.assertTrue(connections.isPresent());
-        Assertions.assertEquals(1, connections.get().size());
-
-        String connectionId = connections.get().get(0).getConnectionId();
-        Optional<Map<String, String>> metadata = ac.connectionsSetMetadata(connectionId, ConnectionSetMetaDataRequest
-                .builder()
-                .metadata(Map.of("key1", "value1", "key2", "value2"))
-                .build());
-        Assertions.assertTrue(metadata.isPresent());
-        Assertions.assertEquals("value2", metadata.get().get("key2"));
-
-        metadata = ac.connectionsGetMetadata(connectionId);
-        Assertions.assertTrue(metadata.isPresent());
-        Assertions.assertEquals("value2", metadata.get().get("key2"));
-
-        Optional<String> singleValue = ac.connectionsGetMetadata(connectionId, "key1");
-        Assertions.assertTrue(singleValue.isPresent());
-        Assertions.assertEquals("value1", singleValue.get());
-    }
+public class MultiConnectionRecordTest extends MultiIntegrationTestBase {
 
     @Test
     void testCreateConnectionBetweenAgents() throws Exception {

--- a/src/test/java/org/hyperledger/aries/api/connection/MultiConnectionRecordTest.java
+++ b/src/test/java/org/hyperledger/aries/api/connection/MultiConnectionRecordTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2020-2021 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/acapy-java-client
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.aries.api.connection;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hyperledger.aries.IntegrationTestBase;
+import org.hyperledger.aries.api.exception.AriesException;
+import org.hyperledger.acy_py.generated.model.ConnectionInvitation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class ConnectionRecordTest extends IntegrationTestBase {
+
+    @Test
+    void testDeleteConnection() {
+        assertThrows(AriesException.class, () -> ac.connectionsRemove("1"));
+    }
+
+    @Test
+    void testGetConnections() throws Exception {
+        final Optional<List<ConnectionRecord>> connections = ac.connections(
+                ConnectionFilter.builder().state(ConnectionState.ACTIVE).build());
+        assertTrue(connections.isPresent());
+        assertEquals(0, connections.get().size());
+    }
+
+    @Test
+    void testGetConnectionsWrongFilter() {
+        assertThrows(AriesException.class, () -> ac.connections(
+            ConnectionFilter.builder().myDid("wrong_format").build()));
+    }
+
+    @Test
+    void testCreateInvitation() throws Exception {
+        final Optional<CreateInvitationResponse> inv = ac.connectionsCreateInvitation(
+                CreateInvitationRequest
+                        .builder()
+                        .recipientKeys(List.of())
+                        .build(),
+                CreateInvitationParams
+                        .builder()
+                        .autoAccept(Boolean.TRUE)
+                        .build());
+        assertTrue(inv.isPresent());
+        assertNotNull(inv.get().getInvitationUrl());
+        log.debug("{}", inv.get());
+    }
+
+    @Test
+    void testMetadata() throws Exception {
+        ac.connectionsCreateInvitation(
+                CreateInvitationRequest
+                        .builder()
+                        .recipientKeys(List.of())
+                        .build(),
+                CreateInvitationParams
+                        .builder()
+                        .autoAccept(Boolean.TRUE)
+                        .build());
+
+        Optional<List<ConnectionRecord>> connections = ac.connections();
+        Assertions.assertTrue(connections.isPresent());
+        Assertions.assertEquals(1, connections.get().size());
+
+        String connectionId = connections.get().get(0).getConnectionId();
+        Optional<Map<String, String>> metadata = ac.connectionsSetMetadata(connectionId, ConnectionSetMetaDataRequest
+                .builder()
+                .metadata(Map.of("key1", "value1", "key2", "value2"))
+                .build());
+        Assertions.assertTrue(metadata.isPresent());
+        Assertions.assertEquals("value2", metadata.get().get("key2"));
+
+        metadata = ac.connectionsGetMetadata(connectionId);
+        Assertions.assertTrue(metadata.isPresent());
+        Assertions.assertEquals("value2", metadata.get().get("key2"));
+
+        Optional<String> singleValue = ac.connectionsGetMetadata(connectionId, "key1");
+        Assertions.assertTrue(singleValue.isPresent());
+        Assertions.assertEquals("value1", singleValue.get());
+    }
+
+    @Test
+    void testCreateConnectionBetweenAgents() throws Exception {
+        String alias_1 = "my_test_1";
+        String alias_2 = "my_test_2";
+        final Optional<CreateInvitationResponse> inv = ac.connectionsCreateInvitation(
+                CreateInvitationRequest
+                        .builder()
+                        .recipientKeys(List.of())
+                        .build(),
+                CreateInvitationParams
+                        .builder()
+                        .autoAccept(Boolean.TRUE)
+                        .alias(alias_1)
+                        .build());
+        assertTrue(inv.isPresent());
+        assertNotNull(inv.get().getInvitationUrl());
+
+        ConnectionInvitation conn_inv = inv.get().getInvitation();
+        final Optional<ConnectionRecord> conn2 = ac2.connectionsReceiveInvitation(
+                ReceiveInvitationRequest
+                        .builder()
+                        .id(conn_inv.getAtId())
+                        .type(conn_inv.getAtType())
+                        .did(conn_inv.getDid())
+                        .imageUrl(conn_inv.getImageUrl())
+                        .label(conn_inv.getLabel())
+                        .recipientKeys(conn_inv.getRecipientKeys())
+                        .routingKeys(conn_inv.getRoutingKeys())
+                        .serviceEndpoint(conn_inv.getServiceEndpoint())
+                        .build(),
+                ConnectionReceiveInvitationFilter
+                        .builder()
+                        .alias(alias_2)
+                        .autoAccept(false)
+                        .build());
+        assertTrue(conn2.isPresent());
+
+        final Optional<ConnectionRecord> conn2_updated = ac2.connectionsAcceptInvitation(
+                conn2.get().getConnectionId(),
+                null);
+        assertTrue(conn2_updated.isPresent());
+
+        // pause to allow the agent chatter to complete
+        Thread.sleep(4000);
+        
+        // now fetch connections and confirm everything completed successfully
+        final Optional<List<ConnectionRecord>> connections = ac.connections(
+                ConnectionFilter.builder().alias(alias_1).build());
+        assertTrue(connections.isPresent());
+        assertEquals(1, connections.get().size());
+        assertEquals(alias_1, connections.get().get(0).getAlias());
+        assertEquals(ConnectionState.ACTIVE, connections.get().get(0).getState());
+        
+        final Optional<List<ConnectionRecord>> connections2 = ac2.connections(
+                ConnectionFilter.builder().alias(alias_2).build());
+        assertTrue(connections2.isPresent());
+        assertEquals(1, connections2.get().size());
+        assertEquals(alias_2, connections2.get().get(0).getAlias());
+        assertEquals(ConnectionState.ACTIVE, connections2.get().get(0).getState());
+    }
+}


### PR DESCRIPTION
Test connection process between 2 agents.

New base class for integration testing with multiple agents.

TODO parametrize agent startup to allow different tests to start agents with different settings.

