### PR TITLE
fix oob record parsing error

### DIFF
--- a/src/main/java/org/hyperledger/aries/api/out_of_band/OOBRecord.java
+++ b/src/main/java/org/hyperledger/aries/api/out_of_band/OOBRecord.java
@@ -43,7 +43,7 @@ public class OOBRecord implements InvitationMessageTranslator {
     private UUID reuseMsgId;
     private UUID oobId;
     private UUID attachThreadId;
-    private UUID ourRecipientKey;
+    private String ourRecipientKey;
     private ProofRequestPresentation.ServiceDecorator ourService;
     private Boolean multiUse;
     private Boolean trace;

--- a/src/test/java/org/hyperledger/aries/IntegrationTestBase.java
+++ b/src/test/java/org/hyperledger/aries/IntegrationTestBase.java
@@ -49,7 +49,15 @@ public abstract class IntegrationTestBase {
     @BeforeEach
     void setup() {
         ac = AriesClient.builder()
-                .url("http://localhost:" + ariesContainer.getMappedPort(ARIES_ADMIN_PORT))
+                .url(getHTTPAdminUrl())
                 .build();
+    }
+
+    public String getHTTPAdminUrl() {
+        return "http://localhost:" + ariesContainer.getMappedPort(ARIES_ADMIN_PORT);
+    }
+
+    public String getWSAdminUrl() {
+        return "ws://localhost:" + ariesContainer.getMappedPort(ARIES_ADMIN_PORT) + "/ws";
     }
 }

--- a/src/test/java/org/hyperledger/aries/api/out_of_band/OOBRecordIntegrationTest.java
+++ b/src/test/java/org/hyperledger/aries/api/out_of_band/OOBRecordIntegrationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020-2022 - for information on the respective copyright owner
+ * see the NOTICE file and/or the repository at
+ * https://github.com/hyperledger-labs/acapy-java-client
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.aries.api.out_of_band;
+
+import org.hyperledger.acy_py.generated.model.InvitationRecord;
+import org.hyperledger.aries.AriesWebSocketClient;
+import org.hyperledger.aries.IntegrationTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+
+public class OOBRecordIntegrationTest extends IntegrationTestBase {
+
+    @Test
+    void testOOBCreateInvitation() throws Exception {
+        InvitationCreateRequest invCreate = InvitationCreateRequest.builder()
+                .alias("test")
+                .usePublicDid(false)
+                .build();
+        CreateInvitationFilter invFilter = CreateInvitationFilter.builder()
+                .autoAccept(Boolean.TRUE)
+                .multiUse(Boolean.TRUE)
+                .build();
+
+        try (AriesWebSocketClient ws = AriesWebSocketClient.builder()
+                .url(getWSAdminUrl())
+                .build()) {
+
+            InvitationRecord invitationRecord = ac.outOfBandCreateInvitation(invCreate, invFilter).orElseThrow();
+
+            UUID oobInvitationMsgId = Objects.requireNonNull(ws.outOfBand().blockFirst(Duration.ofSeconds(5))).getInviMsgId();
+            Assertions.assertEquals(invitationRecord.getInviMsgId(), oobInvitationMsgId.toString());
+        }
+    }
+}

--- a/src/test/java/org/hyperledger/aries/api/out_of_band/OOBRecordTest.java
+++ b/src/test/java/org/hyperledger/aries/api/out_of_band/OOBRecordTest.java
@@ -49,6 +49,7 @@ public class OOBRecordTest {
             "    \"state\": \"initial\",\n" +
             "    \"updated_at\": \"2022-08-11T12:51:45.665135Z\",\n" +
             "    \"oob_id\": \"bb1b9906-f1b4-4c92-96a6-bda81d6282a8\",\n" +
+            "    \"our_recipient_key\": \"8gdhRLtvJHzKoJGyuEqgdN1QZGYfai4wMHFGgtfDXg3D\",\n" +
             "    \"trace\": false\n" +
             "}";
 


### PR DESCRIPTION
fix for: https://github.com/hyperledger-labs/acapy-java-client/issues/62

ourRecipientKey is not a UUID but a verkey and hence a string.

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>